### PR TITLE
Enhancing Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ zcash-qt-wallet is a z-Addr first, Sapling compatible wallet for zcashd that run
 
 Head over to the releases page and grab the latest binary. https://github.com/adityapk00/zcash-qt-wallet/releases
 
-
 ### Linux
 Extract and run the binary
 ```
@@ -18,18 +17,31 @@ tar -xvf zcash-qt-wallet-v0.2.0.tar.gz
 Unzip the release binary and double click on zcash-qt-wallet to start.
 
 ## Prerequisites: zcashd
-zcash-qt-wallet needs a zcash node running zcashd. Download the zcash node software 
-from https://z.cash/download/ and start zcashd. If you are running Windows, you can 
-get [WinZEC Command Line daemon](https://zcash.dl.mercerweiss.com/zcash-win-v2.0.1.zip) or run zcashd inside [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+zcash-qt-wallet needs a Zcash node running zcashd. Linux users should download the zcash node software 
+from [https://z.cash/download/](https://z.cash/download/), configure `zcash.conf`, download the parameters and start zcashd according to the [official documentation](https://zcash.readthedocs.io/en/latest/rtd_pages/user_guide.html). 
 
-zcashd needs to run with RPC enabled and with a RPC username/password set. Add the following entries into ~/.zcash/zcash.conf
+There is currently no official zcashd build for Windows so Windows users may either [cross-compile from source on Linux](https://zcash.readthedocs.io/en/latest/rtd_pages/user_guide.html#installation) to generate the necessary zcashd executables or simply download community hosted pre-compiled executables such as those hosted by WinZEC developer [@radix42](https://github.com/radix42) at [https://zcash.dl.mercerweiss.com/zcash-win-v2.0.1.zip].
+
+Alternitavely run zcashd inside [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+
+For all installations zcashd needs to run with RPC enabled (`server=1`, which is the default) and with a RPC username/password set. Add the following entries into `~/.zcash/zcash.conf` for Linux or` C:\Users\your-username\AppData\Roaming\Zcash\zcash.conf` on Windows. 
 
 ```
 rpcuser=username
 rpcpassword=password
 ```
-zcash-qt-wallet should auto-detect zcashd and WinZEC. If you are running zcashd on WSL, then please set the connection parameters in the File->Settings menu. 
 
+Additionaly for Windows users the Zcash parameters must be manually downloaded and placed in `C:\Users\your-username\AppData\Roaming\ZcashParams`.  The following files are required (and are around ~1.7GB in total).
+
+```
+https://z.cash/downloads/sapling-spend.params
+https://z.cash/downloads/sapling-output.params
+https://z.cash/downloads/sprout-groth16.params
+https://z.cash/downloads/sprout-proving.key
+https://z.cash/downloads/sprout-verifying.key
+```
+
+zcash-qt-wallet should auto-detect zcashd. If you are running zcashd on WSL, then please set the connection parameters in the `File->Settings` menu. 
 
 ## Compiling from source
 zcash-qt-wallet is written in C++ 14, and can be compiled with g++/clang++/visual c++. It also depends on Qt5, which you can get from here: https://www.qt.io/download
@@ -76,4 +88,4 @@ ssh -L8232:127.0.0.1:8232 user@remotehost
 The most likely cause for this is that you are trying to spend unconfirmed funds. Unlike bitcoin, the zcash protocol doesn't let you spent unconfirmed funds yet. Please wait for 
 1-2 blocks for the funds to confirm and retry the transaction. 
 
-PS: zcash-qt-wallet is NOT an official wallet, and is not affiliated with the ZCash Company in any way. 
+_PS: zcash-qt-wallet is NOT an official wallet, and is not affiliated with the Zerocoin Electric Coin Company in any way._


### PR DESCRIPTION
Attempting to add some better instructions for Windows users. WinZEC is actually the GUI wallet whereas the files linked are pre-compiled Windows binaries (and it is now possible to cross-compile directly from source) so trying to clear up that confusion.

Also just downloading those files isn't enough as you need the parameters and in the right location which I've added.

Ideally, as this isn't simple for Windows users, you should generate the executables and bundle them all up and add a script to download the parameters i.e. https://github.com/zcash/zcash/blob/master/zcutil/fetch-params.sh. 